### PR TITLE
require whitespace to start property-list block

### DIFF
--- a/Syntaxes/LESS.xml
+++ b/Syntaxes/LESS.xml
@@ -103,7 +103,7 @@
 		<collection name="block">
 			<zone name="property-list.block.less">
 				<starts-with>
-					<expression>(.+)\{</expression>
+					<expression>(.+)\s\{</expression>
 					<capture number="0" name="punctuation.begin"/>
 					<capture number="1" name="punctuation.definition.mixin.less"/>
 				</starts-with>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 ###Easy-to-clone:
 
-`cd ~/Library/Application Support/Espresso/Sugars/  
+`cd ~/Library/Application Support/Espresso/Sugars/
 git clone git://github.com/sgregson/LESS.sugar.git`

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,6 @@
+## Easy-to-clone
+
+```
+cd ~/Library/Application Support/Espresso/Sugars/
+git clone git://github.com/sgregson/LESS.sugar.git
+```

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,0 @@
-###Easy-to-clone:
-
-`cd ~/Library/Application Support/Espresso/Sugars/
-git clone git://github.com/sgregson/LESS.sugar.git`

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 ###Easy-to-clone:
 
-`cd ~/Library/Application Support/Espresso/Sugars/
+`cd ~/Library/Application Support/Espresso/Sugars/  
 git clone git://github.com/sgregson/LESS.sugar.git`

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,4 @@
+###Easy-to-clone:
+
+`cd ~/Library/Application Support/Espresso/Sugars/
+git clone git://github.com/sgregson/LESS.sugar.git`


### PR DESCRIPTION
Prevents start of property-list inside of string. This works fine for expanded css/less code - would likely not affect minified code.

using a variable definition within a string used to make a mess of syntax highlighting, see example:

``` css
@backgroundsPath: "../../path";
#section1 {
    background: url("@{backgroundsPath}/image1.png");
}
#section2 {
    background: url("@{backgroundsPath}/image2.png");
}
```
